### PR TITLE
Add networking skeleton

### DIFF
--- a/src/main/java/inf112/isolasjonsteamet/roborally/network/Client.java
+++ b/src/main/java/inf112/isolasjonsteamet/roborally/network/Client.java
@@ -1,0 +1,23 @@
+package inf112.isolasjonsteamet.roborally.network;
+
+import inf112.isolasjonsteamet.roborally.network.c2spackets.Client2ServerPacket;
+import java.util.concurrent.CompletableFuture;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Represents a client connected to a server.
+ */
+public interface Client {
+
+	/** Send a packet to the server. */
+	void sendToServer(Client2ServerPacket packet);
+
+	/** Add a listener for packets sent from the server. */
+	void addListener(ClientPacketListener<?> listener);
+
+	/** Remove a packet listener. */
+	void removeListener(ClientPacketListener<?> listener);
+
+	/** Disconnects gracefully from the server, optionally with a reason. */
+	CompletableFuture<Void> disconnect(@Nullable String reason);
+}

--- a/src/main/java/inf112/isolasjonsteamet/roborally/network/ClientPacketListener.java
+++ b/src/main/java/inf112/isolasjonsteamet/roborally/network/ClientPacketListener.java
@@ -1,0 +1,94 @@
+package inf112.isolasjonsteamet.roborally.network;
+
+import inf112.isolasjonsteamet.roborally.network.s2cpackets.Server2ClientPacket;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * A listener for packets sent from the server.
+ *
+ * @param <T> The packet to listen to.
+ */
+public interface ClientPacketListener<T extends Server2ClientPacket> {
+
+	/**
+	 * Creates a listener which listens for a single packet type.
+	 *
+	 * @param clazz The packet type to listen for.
+	 * @param handler A function to execute whenever a packet of the given type is received.
+	 */
+	static <T extends Server2ClientPacket> ClientPacketListener<T> of(Class<T> clazz, Consumer<T> handler) {
+		return new ClassClientPacketListener<>(clazz) {
+			@Override
+			public void handle(T packet) {
+				handler.accept(packet);
+			}
+		};
+	}
+
+	/**
+	 * Grabs the next packet of packages in in a {@link CompletableFuture} form.
+	 *
+	 * @param client The client to listen for the pack on.
+	 * @param clazz The pack type to listen for.
+	 * @return A promise of the next packet of the given type.
+	 */
+	static <T extends Server2ClientPacket> CompletableFuture<T> next(Client client, Class<T> clazz) {
+		var promise = new CompletableFuture<T>();
+		client.addListener(new ClassClientPacketListener<>(clazz) {
+			@Override
+			public void handle(T packet) {
+				promise.complete(packet);
+				client.removeListener(this);
+			}
+		});
+
+		return promise;
+	}
+
+	/**
+	 * Called for all packets this listener accepts.
+	 */
+	void handle(T packet);
+
+	/**
+	 * Refine any packet into those this handler can handle.
+	 *
+	 * @param packet The packet to refine
+	 * @return The packet in a handleable form, or null if this listener can't handle the given packet.
+	 */
+	@Nullable
+	T refine(Server2ClientPacket packet);
+
+	/**
+	 * Handle the given packet if this listener supports it.
+	 */
+	default void handleIfPossible(Server2ClientPacket msg) {
+		T refined = refine(msg);
+		if (refined != null) {
+			handle(refined);
+		}
+	}
+
+	/**
+	 * A {@link ClientPacketListener} which listens for a single type specified by the class it takes.
+	 */
+	abstract class ClassClientPacketListener<T extends Server2ClientPacket> implements ClientPacketListener<T> {
+
+		private final Class<T> clazz;
+
+		protected ClassClientPacketListener(Class<T> clazz) {
+			this.clazz = clazz;
+		}
+
+		@Override
+		public @Nullable T refine(Server2ClientPacket packet) {
+			if (clazz.isInstance(packet)) {
+				return clazz.cast(packet);
+			}
+
+			return null;
+		}
+	}
+}

--- a/src/main/java/inf112/isolasjonsteamet/roborally/network/Packet.java
+++ b/src/main/java/inf112/isolasjonsteamet/roborally/network/Packet.java
@@ -1,0 +1,8 @@
+package inf112.isolasjonsteamet.roborally.network;
+
+/**
+ * Top interface for all packets.
+ */
+public interface Packet {
+
+}

--- a/src/main/java/inf112/isolasjonsteamet/roborally/network/Server.java
+++ b/src/main/java/inf112/isolasjonsteamet/roborally/network/Server.java
@@ -1,0 +1,38 @@
+package inf112.isolasjonsteamet.roborally.network;
+
+import inf112.isolasjonsteamet.roborally.network.s2cpackets.Server2ClientPacket;
+import java.util.concurrent.CompletableFuture;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Represents a server which clients can connect to.
+ */
+public interface Server {
+
+	/**
+	 * Send a packet to all active players of the game.
+	 *
+	 * @param packet The packet to send to all the players.
+	 */
+	void sendToAllPlayers(Server2ClientPacket packet);
+
+	/**
+	 * Send a packet to a single player in a game.
+	 *
+	 * @param player The player to send the packet to
+	 * @param packet The packet to send
+	 */
+	void sendToPlayer(String player, Server2ClientPacket packet);
+
+	/** Add a listener for packets sent from the clients. */
+	void addListener(ServerPacketListener<?> listener);
+
+	/** Remove a packet listener. */
+	void removeListener(ServerPacketListener<?> listener);
+
+	/**
+	 * Gracefully disconnect everyone connected to this server, and then shuts down the server, optionally with a
+	 * reason.
+	 */
+	CompletableFuture<Void> close(@Nullable String reason);
+}

--- a/src/main/java/inf112/isolasjonsteamet/roborally/network/ServerPacketListener.java
+++ b/src/main/java/inf112/isolasjonsteamet/roborally/network/ServerPacketListener.java
@@ -1,0 +1,127 @@
+package inf112.isolasjonsteamet.roborally.network;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import inf112.isolasjonsteamet.roborally.network.c2spackets.Client2ServerPacket;
+import java.util.function.Consumer;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * A listener for packets sent from the clients.
+ *
+ * @param <T> The packet to listen to.
+ */
+public interface ServerPacketListener<T extends Client2ServerPacket> {
+
+	/**
+	 * Creates a listener which listens for a single packet type.
+	 *
+	 * @param clazz The packet type to listen for.
+	 * @param handler A function to execute whenever a packet of the given type is received.
+	 */
+	static <T extends Client2ServerPacket> ServerPacketListener<T> of(
+			Class<T> clazz, Consumer<ServerPacket<T>> handler
+	) {
+		return new ClassServerPacketListener<>(clazz) {
+			@Override
+			public void handle(String player, T packet) {
+				handler.accept(new ServerPacket<>(player, packet));
+			}
+		};
+	}
+
+	/**
+	 * Called for all packets this listener accepts.
+	 *
+	 * @param player The player associated with the packet, or null if the sender hasn't joined the game yet.
+	 */
+	void handle(@Nullable String player, T packet);
+
+	/**
+	 * Refine any packet into those this handler can handle.
+	 *
+	 * @param packet The packet to refine
+	 * @return The packet in a handleable form, or null if this listener can't handle the given packet.
+	 */
+	@Nullable
+	T refine(Client2ServerPacket packet);
+
+	/**
+	 * Handle the given packet if this listener supports it.
+	 */
+	default void handleIfPossible(@Nullable String player, Client2ServerPacket msg) {
+		T refined = refine(msg);
+		if (refined != null) {
+			handle(player, refined);
+		}
+	}
+
+	/**
+	 * A {@link ServerPacketListener} which listens for a single type specified by the class it takes.
+	 */
+	abstract class ClassServerPacketListener<T extends Client2ServerPacket> implements ServerPacketListener<T> {
+
+		private final Class<T> clazz;
+
+		public ClassServerPacketListener(Class<T> clazz) {
+			this.clazz = clazz;
+		}
+
+		@Override
+		public @Nullable T refine(Client2ServerPacket packet) {
+			if (clazz.isInstance(packet)) {
+				return clazz.cast(packet);
+			}
+
+			return null;
+		}
+	}
+
+	/**
+	 * A data type which combines all the parameters passed to {@link #handle(String, Client2ServerPacket)}.
+	 */
+	class ServerPacket<T> {
+
+		private final String player;
+		private final T packet;
+
+		public ServerPacket(String player, T packet) {
+			this.player = player;
+			this.packet = packet;
+		}
+
+		public String getPlayer() {
+			return player;
+		}
+
+		public T getPacket() {
+			return packet;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			ServerPacket<?> that = (ServerPacket<?>) o;
+			return Objects.equal(player, that.player)
+					&& Objects.equal(packet, that.packet);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hashCode(player, packet);
+		}
+
+		@Override
+		public String toString() {
+			return MoreObjects.toStringHelper(this)
+					.add("player", player)
+					.add("packet", packet)
+					.toString();
+		}
+	}
+}

--- a/src/main/java/inf112/isolasjonsteamet/roborally/network/c2spackets/Client2ServerPacket.java
+++ b/src/main/java/inf112/isolasjonsteamet/roborally/network/c2spackets/Client2ServerPacket.java
@@ -1,0 +1,10 @@
+package inf112.isolasjonsteamet.roborally.network.c2spackets;
+
+import inf112.isolasjonsteamet.roborally.network.Packet;
+
+/**
+ * Top interface for all packets sent from the client to server.
+ */
+public interface Client2ServerPacket extends Packet {
+
+}

--- a/src/main/java/inf112/isolasjonsteamet/roborally/network/c2spackets/ClientDisconnectingPacket.java
+++ b/src/main/java/inf112/isolasjonsteamet/roborally/network/c2spackets/ClientDisconnectingPacket.java
@@ -1,0 +1,48 @@
+package inf112.isolasjonsteamet.roborally.network.c2spackets;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Sent to the server before a client disconnects. If this packet is not sent before disconnecting, the server will
+ * assume the client lost connection because of a network error.
+ */
+public class ClientDisconnectingPacket implements Client2ServerPacket {
+
+	@Nullable
+	private final String reason;
+
+	public ClientDisconnectingPacket(@Nullable String reason) {
+		this.reason = reason;
+	}
+
+	@Nullable
+	public String getReason() {
+		return reason;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		ClientDisconnectingPacket that = (ClientDisconnectingPacket) o;
+		return Objects.equal(reason, that.reason);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hashCode(reason);
+	}
+
+	@Override
+	public String toString() {
+		return MoreObjects.toStringHelper(this)
+				.add("reason", reason)
+				.toString();
+	}
+}

--- a/src/main/java/inf112/isolasjonsteamet/roborally/network/impl/SingleplayerClientServer.java
+++ b/src/main/java/inf112/isolasjonsteamet/roborally/network/impl/SingleplayerClientServer.java
@@ -1,0 +1,122 @@
+package inf112.isolasjonsteamet.roborally.network.impl;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+
+import inf112.isolasjonsteamet.roborally.network.Client;
+import inf112.isolasjonsteamet.roborally.network.ClientPacketListener;
+import inf112.isolasjonsteamet.roborally.network.Server;
+import inf112.isolasjonsteamet.roborally.network.ServerPacketListener;
+import inf112.isolasjonsteamet.roborally.network.c2spackets.Client2ServerPacket;
+import inf112.isolasjonsteamet.roborally.network.c2spackets.ClientDisconnectingPacket;
+import inf112.isolasjonsteamet.roborally.network.s2cpackets.Server2ClientPacket;
+import inf112.isolasjonsteamet.roborally.network.s2cpackets.ServerClosingPacket;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * A dummy server which just passes through packets sent on one side to the other side's listeners immediately.
+ *
+ * <p>
+ * Only one player can send packets to the server at a time. The player doing this can be specified with {@link
+ * #setActivePlayer(String)}. This client-server is handshake-less. There is no startup procedure. Shutdown happens as
+ * usual. When all players have disconnected from the server, or the server has closed, this object will enter a state
+ * where no more methods must be called on it. From this point forwards, all methods will throw, as the server has
+ * closed.
+ * </p>
+ */
+public class SingleplayerClientServer implements Client, Server {
+
+	private final List<ServerPacketListener<?>> serverPacketListeners = new CopyOnWriteArrayList<>();
+	private final List<ClientPacketListener<?>> clientPacketListeners = new CopyOnWriteArrayList<>();
+
+	private final List<String> players;
+	private String activePlayer;
+	private boolean isClosed;
+
+	/**
+	 * Creates a new server-client with the given players connected. At least one player must be specified.
+	 */
+	public SingleplayerClientServer(Set<String> players) {
+		checkArgument(!players.isEmpty(), "Can't construct a singleplayer client server with no players");
+		this.players = new CopyOnWriteArrayList<>(players);
+		this.activePlayer = this.players.get(0);
+	}
+
+	private void checkNotClosed() {
+		checkState(!isClosed);
+	}
+
+	@Override
+	public void sendToServer(Client2ServerPacket packet) {
+		checkNotClosed();
+		serverPacketListeners.forEach(listener -> listener.handleIfPossible(activePlayer, packet));
+	}
+
+	public void setActivePlayer(String player) {
+		checkNotClosed();
+		this.activePlayer = activePlayer;
+	}
+
+	@Override
+	public void sendToAllPlayers(Server2ClientPacket packet) {
+		checkNotClosed();
+		clientPacketListeners.forEach(listener -> listener.handleIfPossible(packet));
+	}
+
+	@Override
+	public void sendToPlayer(String player, Server2ClientPacket packet) {
+		checkNotClosed();
+		if (players.contains(player)) {
+			clientPacketListeners.forEach(listener -> listener.handleIfPossible(packet));
+		}
+	}
+
+	@Override
+	public void addListener(ClientPacketListener<?> listener) {
+		checkNotClosed();
+		clientPacketListeners.add(listener);
+	}
+
+	@Override
+	public void addListener(ServerPacketListener<?> listener) {
+		checkNotClosed();
+		serverPacketListeners.add(listener);
+	}
+
+	@Override
+	public void removeListener(ClientPacketListener<?> listener) {
+		checkNotClosed();
+		clientPacketListeners.remove(listener);
+	}
+
+	@Override
+	public void removeListener(ServerPacketListener<?> listener) {
+		checkNotClosed();
+		serverPacketListeners.remove(listener);
+	}
+
+	@Override
+	public CompletableFuture<Void> disconnect(@Nullable String reason) {
+		sendToServer(new ClientDisconnectingPacket(reason));
+		players.remove(activePlayer);
+		if (!players.isEmpty()) {
+			activePlayer = players.get(0);
+		} else {
+			isClosed = true;
+		}
+
+		return CompletableFuture.completedFuture(null);
+	}
+
+	@Override
+	public CompletableFuture<Void> close(@Nullable String reason) {
+		sendToAllPlayers(new ServerClosingPacket(reason));
+		players.clear();
+		isClosed = true;
+		return CompletableFuture.completedFuture(null);
+	}
+}

--- a/src/main/java/inf112/isolasjonsteamet/roborally/network/s2cpackets/Server2ClientPacket.java
+++ b/src/main/java/inf112/isolasjonsteamet/roborally/network/s2cpackets/Server2ClientPacket.java
@@ -1,0 +1,10 @@
+package inf112.isolasjonsteamet.roborally.network.s2cpackets;
+
+import inf112.isolasjonsteamet.roborally.network.Packet;
+
+/**
+ * Top interface for all packets sent from the server to one or more clients.
+ */
+public interface Server2ClientPacket extends Packet {
+
+}

--- a/src/main/java/inf112/isolasjonsteamet/roborally/network/s2cpackets/ServerClosingPacket.java
+++ b/src/main/java/inf112/isolasjonsteamet/roborally/network/s2cpackets/ServerClosingPacket.java
@@ -1,0 +1,47 @@
+package inf112.isolasjonsteamet.roborally.network.s2cpackets;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Sent by the server right before it closes gracefully.
+ */
+public class ServerClosingPacket implements Server2ClientPacket {
+
+	@Nullable
+	private final String reason;
+
+	public ServerClosingPacket(@Nullable String reason) {
+		this.reason = reason;
+	}
+
+	@Nullable
+	public String getReason() {
+		return reason;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		ServerClosingPacket that = (ServerClosingPacket) o;
+		return Objects.equal(reason, that.reason);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hashCode(reason);
+	}
+
+	@Override
+	public String toString() {
+		return MoreObjects.toStringHelper(this)
+				.add("reason", reason)
+				.toString();
+	}
+}


### PR DESCRIPTION
Add code needed to represent a client server architecture, without the networking part. This PR contains a simple implementation of the client-server structure called `SingleplayerClientServer ` which is just a pass through, minimal implementation of the interfaces that can be used for initial development and in tests.